### PR TITLE
minor bugfix: when listing is empty, do not lose the Title and Footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `s_kaplan_meier()` range censoring indicator handling to no longer produce `NA` values in the output when either all subjects are censored or none are censored.
 - Fixed the hanging indent in the first column of the body of the table (#138)
 - Export `leftside()`, `postfun_eq5d` `ac_blank_line` and `tt_to_tblfile` 
+- Fixed `tt_to_tlgrtf()`, when exporting an empty listing do not lose Title and Footers
 
 ### Changed
 - refactored functions `tt_to_flextable_j()` and `export_as_docx_j()`

--- a/R/tt_to_tblfile.R
+++ b/R/tt_to_tblfile.R
@@ -394,7 +394,9 @@ tt_to_tlgrtf <- function(
     tt <- as_listing(
       df,
       key_cols = get_keycols(tt),
-      disp_cols = listing_dispcols(tt)
+      disp_cols = listing_dispcols(tt),
+      main_title = attr(tt, "main_title"),
+      main_footer = attr(tt, "main_footer")
     )
   }
 

--- a/tests/testthat/_snaps/tt_to_tblfile/testemptylisting.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testemptylisting.rtf
@@ -12,7 +12,7 @@
 \clmrg\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6611 
 \clmrg\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7314 
 \clmrg\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8252 
-\clmrg\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs20 \b \pnhang\trhdr\fi-1152\li1152\keepn\s15 testemptylisting:\tab \b0 \cell
+\clmrg\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs20 \b \pnhang\trhdr\fi-1152\li1152\keepn\s15 testemptylisting:\tab This is a title\b0 \cell
 \pard\intbl\ql\fs20 \b \b0 \cell
 \pard\intbl\ql\fs20 \b \b0 \cell
 \pard\intbl\ql\fs20 \b \b0 \cell
@@ -70,6 +70,54 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
+\row
+}
+
+{
+\trowd
+\trqc \clmgf\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx3001 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx3751 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx4736 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx5486 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx5861 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx6189 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx6611 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx7314 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx8252 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx9189 \pard\intbl\ql\fs16 \line Footer 1 \cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\row
+}
+
+{
+\trowd
+\trqc \clmgf\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx3001 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx3751 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx4736 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx5486 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx5861 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx6189 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx6611 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx7314 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx8252 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx9189 \pard\intbl\ql\fs16 Footer 2 \cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
 \row
 }
 

--- a/tests/testthat/test-tt_to_tblfile.R
+++ b/tests/testthat/test-tt_to_tblfile.R
@@ -152,6 +152,12 @@ test_that("tt_to_tlgrtf works with input Table and fontspec size 8", {
 
 test_that("tt_to_tlgrtf works with an empty listing", {
   empty_lsting <- as_listing(ex_adsl[numeric(), 1:10])
+  tab_titles <- list(
+    title = "This is a title",
+    main_footer = c("Footer 1", "Footer 2"),
+    prov_footer = "This is a footer"
+  )
+  empty_lsting <- set_titles(empty_lsting, tab_titles)
   expect_snapshot_file(compare = compare_file_text, rtf_out_wrapper(empty_lsting, "testemptylisting"), cran = TRUE)
   expect_error(
     tt_to_tlgrtf("hi"),


### PR DESCRIPTION
# Pull Request

Minor bugfix: when listing is empty, do not lose Title and Footers when exporting to RTF.


## Checks

- [x] (Have you updated the changelog.md ?)