### PR TITLE
Hotfix in tt_to_tlgrtf() when exporting an empty listing do not lose …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed `tt_to_tlgrtf()` argument `label_width_ins` which was not applying the change in the row label column width (#166).
+- Fixed `tt_to_tlgrtf()`, when exporting an empty listing do not lose Title and Footers
+
 
 ## [0.1.3] - 2026-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - Unreleased
+
+### Fixed
+- Fixed `tt_to_tlgrtf()`, when exporting an empty listing do not lose Title and Footers
+
+
 ## [0.1.3] - 2026-01-12
 
 ### Changed

--- a/R/tt_to_tblfile.R
+++ b/R/tt_to_tblfile.R
@@ -392,7 +392,9 @@ tt_to_tlgrtf <- function(
     tt <- as_listing(
       df,
       key_cols = get_keycols(tt),
-      disp_cols = listing_dispcols(tt)
+      disp_cols = listing_dispcols(tt),
+      main_title = attr(tt, "main_title"),
+      main_footer = attr(tt, "main_footer")
     )
   }
 

--- a/tests/testthat/_snaps/tt_to_tblfile/testemptylisting.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testemptylisting.rtf
@@ -12,7 +12,7 @@
 \clmrg\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6611 
 \clmrg\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7314 
 \clmrg\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8252 
-\clmrg\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs20 \b \pnhang\trhdr\fi-1152\li1152\keepn\s15 testemptylisting:\tab \b0 \cell
+\clmrg\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs20 \b \pnhang\trhdr\fi-1152\li1152\keepn\s15 testemptylisting:\tab This is a title\b0 \cell
 \pard\intbl\ql\fs20 \b \b0 \cell
 \pard\intbl\ql\fs20 \b \b0 \cell
 \pard\intbl\ql\fs20 \b \b0 \cell
@@ -70,6 +70,54 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
+\row
+}
+
+{
+\trowd
+\trqc \clmgf\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx3001 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx3751 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx4736 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx5486 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx5861 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx6189 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx6611 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx7314 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx8252 
+\clmrg\clbrdrt\brdrs\brdrw18\brdrcf1\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx9189 \pard\intbl\ql\fs16 \line Footer 1 \cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\pard\intbl\qc\line Footer 1\cell
+\row
+}
+
+{
+\trowd
+\trqc \clmgf\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx3001 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx3751 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx4736 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx5486 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx5861 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx6189 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx6611 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx7314 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx8252 
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx9189 \pard\intbl\ql\fs16 Footer 2 \cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
+\pard\intbl\qcFooter 2\cell
 \row
 }
 

--- a/tests/testthat/test-tt_to_tblfile.R
+++ b/tests/testthat/test-tt_to_tblfile.R
@@ -152,6 +152,12 @@ test_that("tt_to_tlgrtf works with input Table and fontspec size 8", {
 
 test_that("tt_to_tlgrtf works with an empty listing", {
   empty_lsting <- as_listing(ex_adsl[numeric(), 1:10])
+  tab_titles <- list(
+    title = "This is a title",
+    main_footer = c("Footer 1", "Footer 2"),
+    prov_footer = "This is a footer"
+  )
+  empty_lsting <- set_titles(empty_lsting, tab_titles)
   expect_snapshot_file(compare = compare_file_text, rtf_out_wrapper(empty_lsting, "testemptylisting"), cran = TRUE)
   expect_error(
     tt_to_tlgrtf("hi"),


### PR DESCRIPTION
…Title and Footers

# Pull Request

bugfix in `tt_to_tlgrtf()` when exporting an empty listing do not lose Title and Footers

## Checks

- [x] (Have you updated the changelog.md ?)