### PR TITLE
Update table_and_listing_customizations.rmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - refactored functions `tt_to_flextable_j()` and `export_as_docx_j()`
+- updated vignette to explain correctly how to insert newlines in the headers of Tables and Listings (#179)
 
 ## [0.1.3] - 2026-01-12
 

--- a/vignettes/table_and_listing_customizations.rmd
+++ b/vignettes/table_and_listing_customizations.rmd
@@ -877,17 +877,23 @@ tt_to_tlgrtf(result,
 ### Table .docx File
 
 In order to get the dose level to appear on a new line, then the TRT01A
-variable values will need to be updated to include the text "\\n"
-between the drug name and dose level.
+variable values will need to be updated to include a markup/keyword of your
+choice (e.g. "\\\\line") between the drug name and dose level, and passed
+through argument "string_map".
+
+```{r string_map_newline}
+string_map_newline <- rbind(default_str_map, c("\\line", "\n"))
+string_map_newline
+```
 
 
 ```{r newline_table_docx}
 library(junco)
 library(rtables)
 
-adsl <- data.frame(TRT01A = c("Example Drug\n 5 mg",
-                              "Example Drug\n 10 mg",
-                              "Example Drug\n 20 mg",
+adsl <- data.frame(TRT01A = c("Example Drug\\line5 mg",
+                              "Example Drug\\line10 mg",
+                              "Example Drug\\line20 mg",
                               "Placebo"),
                    SUBJECT = c("1",
                                "2",
@@ -917,13 +923,15 @@ result <- set_titles(result, titles)
 export_as_docx_j(result,
                 tblid = "examplenewline",
                 output_dir = out_dir,
-                orientation = "landscape")
+                orientation = "landscape",
+                string_map = string_map_newline)
 
 ```
 
 ### Visual Output (HTML Representation)
 ```{r newline_table_rtf_display, echo=FALSE, fig.align="center", out.width="100%", out.height="200px"}
-tt_to_flextable_j(result, "newlinetable", orientation = "landscape")
+tt_to_flextable_j(result, "newlinetable", orientation = "landscape",
+                  string_map = string_map_newline)
 ```
 
 ### Listing .rtf File
@@ -974,7 +982,7 @@ tt_to_tlgrtf(result,
 
 If a .docx file is to be created for the listing, new lines can be inserted into the column header by updating the variable label that corresponds with the column of interest.
 
-By adding in "\\n" to the TRT01A variable label, a new line is inserted after "Actual Treatment".
+By adding in "\\\\line" to the TRT01A variable label, a new line is inserted after "Actual Treatment".
 
 ```{r newline_listing_docx}
 library(junco)
@@ -994,7 +1002,7 @@ adsl <- data.frame(TRT01A = c("Example Drug 5 mg",
                               64
                    )
 ) |>
-  formatters::var_relabel(TRT01A = "Actual Treatment for\n Period 01") |>
+  formatters::var_relabel(TRT01A = "Actual Treatment for\\linePeriod 01") |>
   formatters::var_relabel(SUBJECT = "Subject") |>
   formatters::var_relabel(HEIGHT = "Height (in)")
 
@@ -1009,12 +1017,14 @@ result <- set_titles(result, titles)
 export_as_docx_j(result,
                 tblid = "examplelistingnewline2",
                 output_dir = out_dir,
-                orientation = "landscape")
+                orientation = "landscape",
+                string_map = string_map_newline)
 ```
 
 ### Visual Output (HTML Representation)
 ```{r newline_listing_rtf_display, echo=FALSE, fig.align="center", out.width="100%", out.height="200px"}
-tt_to_flextable_j(result, "examplelistingnewline2", orientation = "landscape")
+tt_to_flextable_j(result, "examplelistingnewline2", orientation = "landscape",
+                  string_map = string_map_newline)
 ```
 
 


### PR DESCRIPTION
# Pull Request

Fixes #179 
updated vignette to explain correctly how to insert newlines in the headers of Tables and Listings.


## Checks

- [x] (Have you updated the changelog.md ?)