### PR TITLE
Add unit tests for split funs

### DIFF
--- a/tests/testthat/_snaps/tabulate_lsmeans_wide.md
+++ b/tests/testthat/_snaps/tabulate_lsmeans_wide.md
@@ -1,3 +1,105 @@
+# lsmeans_wide_first_split_fun_fct with variance works as expected
+
+    Code
+      col_info(result)
+    Output
+      An InstantiatedColumnInfo object
+      Columns:
+      reference_group (ID)
+      testing_group (ID)
+      variance (ID)
+      comparison (ID)
+      
+
+---
+
+    Code
+      result
+    Output
+         Reference Group   Testing Group      Testing - Reference
+      ———————————————————————————————————————————————————————————
+
+# lsmeans_wide_first_split_fun_fct without variance works as expected
+
+    Code
+      col_info(result)
+    Output
+      An InstantiatedColumnInfo object
+      Columns:
+      reference_group (ID)
+      testing_group (ID)
+      comparison (ID)
+      
+
+---
+
+    Code
+      result
+    Output
+         Reference Group   Testing Group   Testing - Reference
+      ————————————————————————————————————————————————————————
+
+# lsmeans_wide_second_split_fun_fct works as expected
+
+    Code
+      col_info(result)
+    Output
+      An InstantiatedColumnInfo object
+      Columns:
+      reference_group (ID) -> treatment (ID)
+      reference_group (ID) -> n (ID)
+      reference_group (ID) -> lsmean (ID)
+      reference_group (ID) -> se (ID)
+      testing_group (ID) -> treatment (ID)
+      testing_group (ID) -> n (ID)
+      testing_group (ID) -> lsmean (ID)
+      testing_group (ID) -> se (ID)
+      comparison (ID) -> lsmean (ID)
+      comparison (ID) -> se (ID)
+      comparison (ID) -> ci (ID)
+      comparison (ID) -> pval (ID)
+      
+
+---
+
+    Code
+      result
+    Output
+               Reference Group                 Testing Group                          Testing - Reference               
+         Treatment   N   LS Mean   SE   Treatment   N   LS Mean   SE   LS Mean   SE   92% CI   2-sided p-value~[super a]
+      ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+
+# lsmeans_wide_second_split_fun_fct works with variance and without pval
+
+    Code
+      col_info(result)
+    Output
+      An InstantiatedColumnInfo object
+      Columns:
+      reference_group (ID) -> treatment (ID)
+      reference_group (ID) -> n (ID)
+      reference_group (ID) -> lsmean (ID)
+      reference_group (ID) -> se (ID)
+      testing_group (ID) -> treatment (ID)
+      testing_group (ID) -> n (ID)
+      testing_group (ID) -> lsmean (ID)
+      testing_group (ID) -> se (ID)
+      variance (ID) -> mse (ID)
+      variance (ID) -> df (ID)
+      comparison (ID) -> lsmean (ID)
+      comparison (ID) -> se (ID)
+      comparison (ID) -> ci (ID)
+      
+
+---
+
+    Code
+      result
+    Output
+               Reference Group                 Testing Group                                       Testing - Reference   
+         Treatment   N   LS Mean   SE   Treatment   N   LS Mean   SE   M. S. Error   Error DF    LS Mean    SE    78% CI 
+      ———————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+
 # lsmeans_wide_cfun works as expected
 
     Code

--- a/tests/testthat/test-tabulate_lsmeans_wide.R
+++ b/tests/testthat/test-tabulate_lsmeans_wide.R
@@ -1,5 +1,51 @@
 library(dplyr)
 
+test_that("lsmeans_wide_first_split_fun_fct with variance works as expected", {
+  split_fun <- lsmeans_wide_first_split_fun_fct(include_variance = TRUE)
+  lyt <- basic_table() |>
+    split_cols_by("ID", split_fun = split_fun)
+  result <- expect_silent(build_table(lyt, DM))
+  expect_snapshot(col_info(result))
+  expect_snapshot(result)
+})
+
+test_that("lsmeans_wide_first_split_fun_fct without variance works as expected", {
+  split_fun <- lsmeans_wide_first_split_fun_fct(include_variance = FALSE)
+  lyt <- basic_table() |>
+    split_cols_by("ID", split_fun = split_fun)
+  result <- expect_silent(build_table(lyt, DM))
+  expect_snapshot(col_info(result))
+  expect_snapshot(result)
+})
+
+test_that("lsmeans_wide_second_split_fun_fct works as expected", {
+  split_fun <- lsmeans_wide_second_split_fun_fct(
+    include_pval = TRUE,
+    pval_sided = "2",
+    conf_level = 0.92
+  )
+  lyt <- basic_table() |>
+    split_cols_by("ID", split_fun = lsmeans_wide_first_split_fun_fct(FALSE)) |>
+    split_cols_by("ID", split_fun = split_fun)
+  result <- expect_silent(build_table(lyt, DM))
+  expect_snapshot(col_info(result))
+  expect_snapshot(result)
+})
+
+test_that("lsmeans_wide_second_split_fun_fct works with variance and without pval", {
+  split_fun <- lsmeans_wide_second_split_fun_fct(
+    include_pval = FALSE,
+    pval_sided = "1",
+    conf_level = 0.78
+  )
+  lyt <- basic_table() |>
+    split_cols_by("ID", split_fun = lsmeans_wide_first_split_fun_fct(TRUE)) |>
+    split_cols_by("ID", split_fun = split_fun)
+  result <- expect_silent(build_table(lyt, DM))
+  expect_snapshot(col_info(result))
+  expect_snapshot(result)
+})
+
 test_that("lsmeans_wide_cfun works as expected", {
   df <- data.frame(
     TRT01P = factor(


### PR DESCRIPTION
This just adds unit tests for the two split functions which are now exported and had not been separately unit tested previously.