### PR TITLE
replaced `utils::getFromNamespace()` with exported rtables.officer fu…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Imports:
     mmrm,
     assertthat,
     vcdExtra (>= 0.8.7),
-    rtables.officer (>= 0.1.0),
+    rtables.officer (>= 0.1.2.9001),
     flextable (>= 0.9.11),
     officer,
     xml2,
@@ -82,3 +82,4 @@ Suggests:
     pharmaverseadamjnj (>= 0.0.2)
 VignetteBuilder: knitr
 Config/testthat/edition: 3
+Remotes: insightsengineering/rtables.officer@main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Depends:
     formatters (>= 0.5.12),
     rtables (>= 0.6.15)
 Imports:
-    tidytlg (>= 0.11.0),
+    tidytlg (>= 0.11.0.9000),
     tern (>= 0.9.10),
     rlistings (>= 0.2.13),
     checkmate (>= 2.1.0),
@@ -82,4 +82,6 @@ Suggests:
     pharmaverseadamjnj (>= 0.0.2)
 VignetteBuilder: knitr
 Config/testthat/edition: 3
-Remotes: insightsengineering/rtables.officer@main
+Remotes:
+    insightsengineering/rtables.officer@main
+    pharmaverse/tidytlg@main

--- a/R/docx_exporter_functions.R
+++ b/R/docx_exporter_functions.R
@@ -448,7 +448,7 @@ add_little_gap_bottom_borders_spanning_headers <- function(
 
 insert_footer_text <- function(flx, tblid) {
   if (is.null(getOption("docx.add_datetime")) || isTRUE(getOption("docx.add_datetime"))) {
-    get_file_name <- utils::getFromNamespace("get_file_name", "tidytlg")
+    get_file_name <- tidytlg::get_file_name
     footer_text <- paste0(
       "[", tolower(tblid), ".docx]",
       "[", get_file_name(), "] ",
@@ -1108,7 +1108,7 @@ tt_to_flextable_j <- function(
   content[content == ""] <- " "
   # NOTE:
   # insert blank lines previously calculated
-  content <- utils::getFromNamespace("insert_empty_rows", "tidytlg")(content, newrows)
+  content <- tidytlg::insert_empty_rows(content, newrows)
   # update 'mpf_aligns'
   idx <- which(newrows == 1)
   # NOTE: here, it is important to traverse 'idx' in reverse order

--- a/R/docx_exporter_functions.R
+++ b/R/docx_exporter_functions.R
@@ -471,7 +471,7 @@ insert_title_as_header <- function(flx,
     title_font_size <- 10
     title_font_family <- "Times New Roman"
   } else {
-    flx_fpt <- utils::getFromNamespace(".extract_font_and_size_from_flx", "rtables.officer")(flx)
+    flx_fpt <- rtables.officer::extract_font_and_size_from_flx(flx)
     title_style <- flx_fpt$fpt
     title_font_size <- title_style$font.size + 1 # 10
     title_font_family <- title_style$font.family
@@ -740,11 +740,7 @@ theme_docx_default_j <- function(
     if (any(bold == "top_left")) {
       flx <- flextable::bold(flx, j = 1, part = "header")
     }
-    .apply_bold_manual <- utils::getFromNamespace(
-      ".apply_bold_manual",
-      "rtables.officer"
-    )
-    flx <- .apply_bold_manual(flx, bold_manual)
+    flx <- rtables.officer::apply_bold_manual(flx, bold_manual)
 
     # NOTE: the following block styles the footer and footnotes
     n_footnotes <- flextable::nrow_part(flx, "footer")
@@ -1232,13 +1228,9 @@ tt_to_flextable_j <- function(
     mpf_aligns[al$row, al$col] <- al$value
   }
   if (length(alignments) == 0) {
-    .apply_alignments <- utils::getFromNamespace(
-      ".apply_alignments",
-      "rtables.officer"
-    )
     flx <- flx |>
-      .apply_alignments(mpf_aligns[seq_len(hnum), , drop = FALSE], "header") |>
-      .apply_alignments(mpf_aligns[-seq_len(hnum), , drop = FALSE], "body")
+      rtables.officer::apply_alignments(mpf_aligns[seq_len(hnum), , drop = FALSE], "header") |>
+      rtables.officer::apply_alignments(mpf_aligns[-seq_len(hnum), , drop = FALSE], "body")
   } else {
     # iterate for each row in the header
     for (i in seq_len(hnum)) {
@@ -1670,14 +1662,10 @@ export_as_docx_j <- function(
     stop("tt must be a TableTree/listing_df, a flextable, or a list of TableTree/listing_df or flextable objects.")
   }
   if (isFALSE(titles_as_header) || isFALSE(integrate_footers)) {
-    .extract_font_and_size_from_flx <- utils::getFromNamespace(
-      ".extract_font_and_size_from_flx",
-      "rtables.officer"
-    )
     if (inherits(flex_tbl_list[[1]], "list")) {
-      flx_fpt <- .extract_font_and_size_from_flx(flex_tbl_list[[1]][[1]])
+      flx_fpt <- rtables.officer::extract_font_and_size_from_flx(flex_tbl_list[[1]][[1]])
     } else {
-      flx_fpt <- .extract_font_and_size_from_flx(flex_tbl_list[[1]])
+      flx_fpt <- rtables.officer::extract_font_and_size_from_flx(flex_tbl_list[[1]])
     }
   }
 

--- a/tests/testthat/_snaps/tt_to_tblfile/test1.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test1.rtf
@@ -18,7 +18,7 @@
 \trqc \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadr67\clpadfr3\cellx2828 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx4948 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx7069 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr A: Drug X \cell
 \pard\intbl\qc\fs18 \keepn\trhdr B: Placebo \cell
 \pard\intbl\qc\fs18 \keepn\trhdr C: Combination \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test1b.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test1b.rtf
@@ -18,7 +18,7 @@
 \trqc \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadr67\clpadfr3\cellx2863 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx4971 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx7080 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr A: Drug X \cell
 \pard\intbl\qc\fs18 \keepn\trhdr B: Placebo \cell
 \pard\intbl\qc\fs18 \keepn\trhdr C: Combination \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test2part1of3.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test2part1of3.rtf
@@ -40,7 +40,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5453 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6616 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7903 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test2part2of3.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test2part2of3.rtf
@@ -45,7 +45,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5949 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7065 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8180 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test2part3of3.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test2part3of3.rtf
@@ -20,7 +20,7 @@
 {
 \trowd
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2757 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
 \row
 }

--- a/tests/testthat/_snaps/tt_to_tblfile/test3allparts.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test3allparts.rtf
@@ -40,7 +40,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5394 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6659 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7924 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
@@ -366,7 +366,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6027 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7081 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8135 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
@@ -702,7 +702,7 @@
 {
 \trowd
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2864 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
 \row
 }

--- a/tests/testthat/_snaps/tt_to_tblfile/test4iec.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test4iec.rtf
@@ -18,7 +18,7 @@
 \trqc \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadr67\clpadfr3\cellx2872 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx4786 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx6701 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM A \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM B \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM C \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test4iecmod.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test4iecmod.rtf
@@ -18,7 +18,7 @@
 \trqc \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadr67\clpadfr3\cellx2872 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx4786 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx6701 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM A \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM B \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM C \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test4sas.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test4sas.rtf
@@ -18,7 +18,7 @@
 \trqc \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadr67\clpadfr3\cellx2872 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx4786 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx6701 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM A \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM B \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM C \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart1of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart1of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6161 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7101 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8197 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart2of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart2of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5892 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6919 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8054 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart3of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart3of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6054 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7027 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8162 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart4of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart4of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6053 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7208 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8199 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart5of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart5of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5973 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7045 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8117 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart6of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart6of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6005 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7101 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8093 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell


### PR DESCRIPTION
…nctions

# Pull Request

This PR needs prior acceptance of other 2 external PRs:
- https://github.com/insightsengineering/rtables.officer/pull/68
- https://github.com/pharmaverse/tidytlg/pull/61
Once these are approved and released to CRAN, then this PR can be sent for review (i.e. "undraft" it).

Fixes #174 
In the docx exporter function, replace the `utils::getFromNamespace()` with calls to exported functions:

- tidytlg: get_file_name, insert_empty_rows
- rtables.officer: .apply_bold_manual, .apply_alignments, .extract_font_and_size_from_flx


## Checks

- [x] (Have you updated the changelog.md ?)