### PR TITLE
updated snapshots due to new tidytlg CRAN release v0.12.0

### DIFF
--- a/tests/testthat/_snaps/tt_to_tblfile/test1.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test1.rtf
@@ -18,7 +18,7 @@
 \trqc \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadr67\clpadfr3\cellx2828 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx4948 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx7069 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr A: Drug X \cell
 \pard\intbl\qc\fs18 \keepn\trhdr B: Placebo \cell
 \pard\intbl\qc\fs18 \keepn\trhdr C: Combination \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test1b.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test1b.rtf
@@ -18,7 +18,7 @@
 \trqc \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadr67\clpadfr3\cellx2863 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx4971 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx7080 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr A: Drug X \cell
 \pard\intbl\qc\fs18 \keepn\trhdr B: Placebo \cell
 \pard\intbl\qc\fs18 \keepn\trhdr C: Combination \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test2part1of3.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test2part1of3.rtf
@@ -40,7 +40,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5453 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6616 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7903 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test2part2of3.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test2part2of3.rtf
@@ -45,7 +45,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5949 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7065 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8180 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test2part3of3.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test2part3of3.rtf
@@ -20,7 +20,7 @@
 {
 \trowd
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2757 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
 \row
 }

--- a/tests/testthat/_snaps/tt_to_tblfile/test3allparts.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test3allparts.rtf
@@ -40,7 +40,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5394 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6659 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7924 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
@@ -366,7 +366,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6027 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7081 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8135 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
@@ -702,7 +702,7 @@
 {
 \trowd
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2864 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
 \row
 }

--- a/tests/testthat/_snaps/tt_to_tblfile/test4iec.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test4iec.rtf
@@ -18,7 +18,7 @@
 \trqc \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadr67\clpadfr3\cellx2872 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx4786 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx6701 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM A \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM B \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM C \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test4iecmod.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test4iecmod.rtf
@@ -18,7 +18,7 @@
 \trqc \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadr67\clpadfr3\cellx2872 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx4786 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx6701 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM A \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM B \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM C \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/test4sas.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/test4sas.rtf
@@ -18,7 +18,7 @@
 \trqc \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadr67\clpadfr3\cellx2872 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx4786 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx6701 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\clpadt67\clpadft3\clpadr67\clpadfr3\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM A \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM B \cell
 \pard\intbl\qc\fs18 \keepn\trhdr ARM C \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart1of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart1of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6161 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7101 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8197 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart2of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart2of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5892 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6919 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8054 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart3of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart3of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6054 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7027 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8162 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart4of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart4of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6053 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7208 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8199 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart5of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart5of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5973 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7045 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8117 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell
 \pard\intbl\qc\fs18 \keepn\trhdr M \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell

--- a/tests/testthat/_snaps/tt_to_tblfile/testpagebypart6of6.rtf
+++ b/tests/testthat/_snaps/tt_to_tblfile/testpagebypart6of6.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6005 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7101 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8093 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr U \cell
 \pard\intbl\qc\fs18 \keepn\trhdr UNDIFFERENTIATED \cell
 \pard\intbl\qc\fs18 \keepn\trhdr F \cell


### PR DESCRIPTION
# Pull Request

because of the recent CRAN release of tidytlg v0.12.0, which now replaces leading whitespaces in the table header col 1 of the RTFs with actual left indentation RTF markups, our snapshot tests started to fail. This PR updates the snapshots, using recent tidytlg CRAN version.


## Checks

- [x] (Have you updated the changelog.md ?)