### PR TITLE
bump to 0.1.6.900 + remove internals formatters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: junco
 Title: Create Common Tables and Listings Used in Clinical Trials
-Version: 0.1.6
-Date: 2026-05-06
+Version: 0.1.6.9000
+Date: 2026-05-22
 Authors@R: c(
     person("Gabriel", "Becker", , "gabembecker@gmail.com", role = c("cre", "aut"),
            comment = "Original creator of the package, and author of included rtables functions"),
@@ -32,7 +32,7 @@ URL: https://github.com/johnsonandjohnson/junco, https://johnsonandjohnson.githu
 BugReports: https://github.com/johnsonandjohnson/junco/issues
 Depends:
     R (>= 4.4),
-    formatters (>= 0.5.12),
+    formatters (>= 0.5.12.9003),
     rtables (>= 0.6.16)
 Imports:
     tidytlg (>= 0.12.0),
@@ -78,3 +78,5 @@ Suggests:
     lifecycle
 VignetteBuilder: knitr
 Config/testthat/edition: 3
+Remotes:
+    insightsengineering/formatters@main

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,14 @@
-# junco 0.1.6
+# junco 0.1.6.9000
+
+### Fixed
+
+### Changed
+- Removed formatters exports #317
+
+### Added
+
+## [0.1.6] - 2026-05-05 (CRAN release)
+
 
 ### Fixed
 
@@ -118,6 +128,10 @@
 
 - Initial CRAN release
 
+
+## Changelog
+
+[0.1.6]: https://github.com/johnsonandjohnson/junco/releases/tag/v0.1.6-rc
 [0.1.5]: https://github.com/johnsonandjohnson/junco/releases/tag/v-0.1.5
 [0.1.4]: https://github.com/johnsonandjohnson/junco/releases/tag/0.1.4
 [0.1.3]: https://github.com/johnsonandjohnson/junco/releases/tag/v0.1.3

--- a/R/colwidths.R
+++ b/R/colwidths.R
@@ -470,9 +470,7 @@ one_col_strs <- function(strcol, col_gap = 2, fontspec) {
   ret
 }
 
-## we have permission from the formatters maintainer to use this
-## unexported function
-j_mf_col_widths <- utils::getFromNamespace("mf_col_widths", "formatters")
+
 
 #' @name def_colwidths
 #'
@@ -509,9 +507,9 @@ def_colwidths <- function(tt,
     if (
       is.list(tt) &&
         !methods::is(tt, "MatrixPrintForm") &&
-        !is.null(j_mf_col_widths(tt[[1]]))
+        !is.null(formatters::mf_col_widths(tt[[1]]))
     ) {
-      ret <- j_mf_col_widths(tt[[1]])
+      ret <- formatters::mf_col_widths(tt[[1]])
     } else {
       ret <- no_cellwrap_colwidths(tt, fontspec, col_gap = col_gap, label_width_ins = label_width_ins)
     }

--- a/R/tt_to_tblfile.R
+++ b/R/tt_to_tblfile.R
@@ -550,7 +550,7 @@ tt_to_tlgrtf <- function(
           full_pag_i,
           file = fname,
           orientation = orientation,
-          colwidths = j_mf_col_widths(pgi_for_cw),
+          colwidths = formatters::mf_col_widths(pgi_for_cw),
           fontspec = fontspec,
           watermark = watermark,
           col_gap = col_gap,

--- a/dev/junco_hotfix_v0-1-3.R
+++ b/dev/junco_hotfix_v0-1-3.R
@@ -382,7 +382,7 @@ tt_to_tlgrtf <- function(
           full_pag_i,
           file = fname,
           orientation = orientation,
-          colwidths = junco:::j_mf_col_widths(pgi_for_cw),
+          colwidths = formatters::mf_col_widths(pgi_for_cw),
           fontspec = fontspec,
           watermark = watermark,
           col_gap = col_gap,


### PR DESCRIPTION
# Pull Request

Fixes #317 

From https://github.com/insightsengineering/formatters/pull/374


## Checks

- [x] (Have you updated the NEWS.md ?)
- [x] (Have you added proper tests for new functions/features ?)
- [x] (Have you added new functions to the pkgdown.yml ?)
- [x] (Have you run document() on new functions ?)
